### PR TITLE
Remove unused properties from page route and creation form

### DIFF
--- a/src/components/common/reports/student_data_set.js
+++ b/src/components/common/reports/student_data_set.js
@@ -42,7 +42,6 @@ const ExpandedComponent = ({ data, classrooms, role, user_token }) => {
       cashier: {
         students: { confirm },
       },
-      surveillant: {},
     },
   } = routes.page_route;
 

--- a/src/components/forms/school/creationForm.js
+++ b/src/components/forms/school/creationForm.js
@@ -112,11 +112,6 @@ export const CreateSchoolForm = ({
         },
       },
     },
-    messages: {
-      school: {
-        creation: {},
-      },
-    },
   } = forms;
 
   // Responsive direction for HStack/Stack


### PR DESCRIPTION
Eliminate the unused surveillant property from the page route and remove unnecessary messages from the creation form.